### PR TITLE
expose additional api to reprocess aggregate results

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@ Nils Kenneweg (https://github.com/nkenneweg)
 Eric Burin des Roziers (https://github.com/Ericbdr)
 Tim Ruffles (https://github.com/timruffles)
 Will Boyd (https://github.com/lonekorean)
+Addison Higham (https://github.com/addisonj)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "escomplex",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Software complexity analysis of JavaScript-family abstract syntax trees.",
     "homepage": "https://github.com/philbooth/escomplex",
     "bugs": "https://github.com/philbooth/escomplex/issues",

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@
 var check = require('check-types');
 
 exports.analyse = analyse;
+exports.processResults = processResults;
 
 /**
  * Public function `analyse`.
@@ -29,3 +30,14 @@ function analyse (ast, walker, options) {
     return require('./module').analyse(ast, walker, options);
 }
 
+/**
+ * Public function `processResults`.
+ *
+ * Given an object with an array of results, it returns results with calculated aggregate values.
+ *
+ * @param report {object}  The report object with an array of results for calculating aggregates.
+ *
+ */
+function processResults(report) {
+    return require('./project').processResults(report);
+}

--- a/src/project.js
+++ b/src/project.js
@@ -5,6 +5,7 @@
 var path, check, matrix, moduleAnalyser;
 
 exports.analyse = analyse;
+exports.processResults = processResults;
 
 path = require('path');
 check = require('check-types');
@@ -36,10 +37,12 @@ function analyse (modules, walker, options) {
         }
     }, []);
 
-    result = {
+    return processResults({
         reports: reports,
-    };
+    });
+}
 
+function processResults(result) {
     createAdjacencyMatrix(result);
     createVisibilityMatrix(result);
     setCoreSize(result);


### PR DESCRIPTION
This exposes a new API that allows for recomputing the aggregates scores that `src/project.js` computes.

This is used in philbooth/complexity-report to properly report on scores for mixed js/coffee projects.

