### PR TITLE
Faster visibility matrix and more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,24 @@ by calling `require`:
 var escomplex = require('escomplex');
 ```
 
-It exports one function,
-called `analyse`:
+It exports two functions,
+the primary interface, called `analyse`:
 
 ```javascript
 var result = escomplex.analyse(ast, walker, options);
 ```
+
+and a second function, called `processResults`:
+
+``` javascript
+escomplex.processResults(result, false);
+```
+
+This function takes a report object and computes
+aggregate scores for all individual files and also adjaceny and
+visibility matrices. The second parameter corresponds to `noCoreSize`
+option below.
+
 
 ### Arguments
 
@@ -221,6 +233,14 @@ some of the complexity calculations:
   Boolean indicating whether the maintainability
   index should be rebased on a scale from 0 to 100,
   defaults to `false`.
+* `options.skipCalculation`:
+  *only valid for when ast is an array of files*
+  Boolean indicating if we should skip processing of certain
+  values, such as the adjacency and visibility matrixes, core sizes,
+  and average values loc, etc.
+* `options.noCoreSize`:
+  Skips creating the visibility matrix and calculating the coreSize,
+  which can be very expensive for large projects
 
 ### Result
 

--- a/README.md
+++ b/README.md
@@ -164,28 +164,18 @@ by calling `require`:
 var escomplex = require('escomplex');
 ```
 
-It exports two functions,
-the primary interface, called `analyse`:
+escomplex exports two primary functions,
+`analyze` and `processResults`
+
+### anaylze
 
 ```javascript
 var result = escomplex.analyse(ast, walker, options);
 ```
 
-and a second function, called `processResults`:
+#### Arguments
 
-``` javascript
-escomplex.processResults(result, false);
-```
-
-This function takes a report object and computes
-aggregate scores for all individual files and also adjaceny and
-visibility matrices. The second parameter corresponds to `noCoreSize`
-option below.
-
-
-### Arguments
-
-#### ast
+##### ast
 
 The first argument, `ast`,
 must be either
@@ -201,12 +191,12 @@ each of the result objects,
 that path is also used
 during dependency analysis.
 
-#### walker
+##### walker
 
 The second argument, `walker`,
 must be a [syntax tree walker](#syntax-tree-walkers).
 
-#### options
+##### options
 
 The third argument, `options`,
 is an optional object
@@ -235,14 +225,49 @@ some of the complexity calculations:
   defaults to `false`.
 * `options.skipCalculation`:
   *only valid for when ast is an array of files*
-  Boolean indicating if we should skip processing of certain
-  values, such as the adjacency and visibility matrixes, core sizes,
-  and average values loc, etc.
+  Boolean indicating if we should skip processing of certain values,
+  such as the adjacency and visibility matrixes,
+  core sizes, and average values loc, etc.
 * `options.noCoreSize`:
   Skips creating the visibility matrix and calculating the coreSize,
   which can be very expensive for large projects
 
-### Result
+### processResults
+
+``` javascript
+escomplex.processResults(result, false);
+```
+
+This function takes a report object
+and computes aggregate scores for all individual files
+and also adjacency and visibility matrices.
+This is useful for combining together multiple report objects
+(say from different languages)
+and recomputing aggregate scores.
+
+#### Arguments
+
+##### Result
+A result object of the form:
+
+```JavaScript
+var result = {
+  reports: [
+    {
+      // same format as module return
+    }
+  ]
+}
+```
+
+#### noCoreSize
+a boolean indicating not to calculate the visibilityMatrix or core size
+
+
+### Result Format
+Both `analyze` and `processResults`
+return a report of the following format,
+with some variation depending on the given options.
 
 #### For a single module
 
@@ -437,8 +462,12 @@ are defined as follows:
   Like the adjacency matrix,
   but expanded to incorporate
   indirect dependencies.
+  Will be missing if `noCoreSize` is passed
+  as an option.
 * `result.changeCost`:
   The change cost for the project.
+  Will be missing if `noCoreSize` is passed
+  as an option.
 * `result.coreSize`:
   The core size for the project.
 * `result.loc`:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   ],
   "dependencies": {
     "check-types": "2.1.x",
-    "lodash": "^3.3.1",
     "matrix-utilities": "1.2.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-    "name": "escomplex",
-    "version": "1.1.0",
-    "description": "Software complexity analysis of JavaScript-family abstract syntax trees.",
-    "homepage": "https://github.com/philbooth/escomplex",
-    "bugs": "https://github.com/philbooth/escomplex/issues",
-    "license": "MIT",
-    "author": "Phil Booth <pmbooth@gmail.com> (https://github.com/philbooth)",
-    "main": "./src",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/philbooth/escomplex.git"
-    },
-    "keywords": [
-        "escomplex",
-        "complexity",
-        "simplicity",
-        "cyclomatic",
-        "halstead",
-        "maintainability",
-        "dependencies",
-        "static",
-        "analysis",
-        "metrics",
-        "esprima",
-        "acorn",
-        "ast"
-    ],
-    "dependencies": {
-        "check-types": "2.1.x",
-        "matrix-utilities": "1.2.x"
-    },
-    "devDependencies": {
-        "jshint": "2.1.x",
-        "mocha": "1.13.x",
-        "chai": "1.8.x",
-        "escomplex-ast-moz": "0.1.x",
-        "esprima": "1.0.x"
-    },
-    "scripts": {
-        "lint": "./node_modules/jshint/bin/jshint src --config config/jshint.json",
-        "test": "npm run test-module && npm run test-project",
-        "test-module": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors test/module",
-        "test-project": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors test/project"
-    }
+  "name": "escomplex",
+  "version": "1.2.0",
+  "description": "Software complexity analysis of JavaScript-family abstract syntax trees.",
+  "homepage": "https://github.com/philbooth/escomplex",
+  "bugs": "https://github.com/philbooth/escomplex/issues",
+  "license": "MIT",
+  "author": "Phil Booth <pmbooth@gmail.com> (https://github.com/philbooth)",
+  "main": "./src",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/philbooth/escomplex.git"
+  },
+  "keywords": [
+    "escomplex",
+    "complexity",
+    "simplicity",
+    "cyclomatic",
+    "halstead",
+    "maintainability",
+    "dependencies",
+    "static",
+    "analysis",
+    "metrics",
+    "esprima",
+    "acorn",
+    "ast"
+  ],
+  "dependencies": {
+    "check-types": "2.1.x",
+    "lodash": "^3.3.1",
+    "matrix-utilities": "1.2.x"
+  },
+  "devDependencies": {
+    "jshint": "2.1.x",
+    "mocha": "1.13.x",
+    "chai": "1.8.x",
+    "escomplex-ast-moz": "0.1.x",
+    "esprima": "1.0.x"
+  },
+  "scripts": {
+    "lint": "./node_modules/jshint/bin/jshint src --config config/jshint.json",
+    "test": "npm run test-module && npm run test-project",
+    "test-module": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors test/module",
+    "test-project": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors test/project"
+  }
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,10 @@
 
 'use strict';
 
-var check = require('check-types');
+var check = require('check-types'),
+    project = require('./project'),
+    module = require('./module');
+
 
 exports.analyse = analyse;
 exports.processResults = processResults;
@@ -24,10 +27,10 @@ exports.processResults = processResults;
  */
 function analyse (ast, walker, options) {
     if (check.array(ast)) {
-        return require('./project').analyse(ast, walker, options);
+        return project.analyse(ast, walker, options);
     }
 
-    return require('./module').analyse(ast, walker, options);
+    return module.analyse(ast, walker, options);
 }
 
 /**
@@ -36,8 +39,9 @@ function analyse (ast, walker, options) {
  * Given an object with an array of results, it returns results with calculated aggregate values.
  *
  * @param report {object}  The report object with an array of results for calculating aggregates.
+ * @param noCoreSize {boolean} Don't compute coresize or the visibility matrix.
  *
  */
-function processResults(report) {
-    return require('./project').processResults(report);
+function processResults(report, noCoreSize) {
+    return project.processResults(report, noCoreSize);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@
 'use strict';
 
 var check = require('check-types'),
-    project = require('./project'),
-    module = require('./module');
+    projectHandler = require('./project'),
+    moduleHandler = require('./module');
 
 
 exports.analyse = analyse;
@@ -27,10 +27,10 @@ exports.processResults = processResults;
  */
 function analyse (ast, walker, options) {
     if (check.array(ast)) {
-        return project.analyse(ast, walker, options);
+        return projectHandler.analyse(ast, walker, options);
     }
 
-    return module.analyse(ast, walker, options);
+    return moduleHandler.analyse(ast, walker, options);
 }
 
 /**
@@ -43,5 +43,5 @@ function analyse (ast, walker, options) {
  *
  */
 function processResults(report, noCoreSize) {
-    return project.processResults(report, noCoreSize);
+    return projectHandler.processResults(report, noCoreSize);
 }

--- a/src/project.js
+++ b/src/project.js
@@ -50,14 +50,12 @@ function analyse (modules, walker, options) {
 }
 
 function processResults(result, noCoreSize) {
-    if (noCoreSize === null) {
-        noCoreSize = false;
-    }
     createAdjacencyMatrix(result);
     if (!noCoreSize) {
         createVisibilityMatrix(result);
         setCoreSize(result);
     }
+
     calculateAverages(result);
 
     return result;
@@ -170,7 +168,10 @@ function percentify (value, limit) {
 // implementation of floydWarshall alg for calculating visibility matrix in O(n^3) instead of O(n^4) with successive raising of powers
 function createVisibilityMatrix (result) {
 
-    var changeCost = 0, visibilityMatrix = adjacencyToDistMatrix(result.adjacencyMatrix), matrixLen = visibilityMatrix.length, k, i, j;
+    var changeCost = 0, visibilityMatrix, matrixLen, k, i, j;
+
+    visibilityMatrix = adjacencyToDistMatrix(result.adjacencyMatrix);
+    matrixLen = visibilityMatrix.length;
 
     for (k = 0; k < matrixLen; k += 1) {
         for (i = 0; i < matrixLen; i += 1) {
@@ -180,6 +181,7 @@ function createVisibilityMatrix (result) {
         }
     }
 
+    //convert back from a distance matrix to adjacency matrix, while also calculating change cost
     visibilityMatrix = visibilityMatrix.map(function (row, rowIndex) {
         return row.map(function (value, columnIndex) {
             if (value < Infinity) {
@@ -200,7 +202,6 @@ function createVisibilityMatrix (result) {
     result.changeCost = percentifyDensity(changeCost, visibilityMatrix);
 }
 
-// where we have 0, set distance to Infinity and copy the matrix so its special
 function adjacencyToDistMatrix(matrix) {
     var distMatrix = [], i, j, value;
     for (i = 0; i < matrix.length; i += 1) {
@@ -210,6 +211,7 @@ function adjacencyToDistMatrix(matrix) {
             if (i === j) {
                 value = 1;
             } else {
+                // where we have 0, set distance to Infinity
                 value = matrix[i][j] || Infinity;
             }
             distMatrix[i][j] = value;

--- a/src/project.js
+++ b/src/project.js
@@ -15,7 +15,7 @@ moduleAnalyser = require('./module');
 function analyse (modules, walker, options) {
     // TODO: Asynchronize.
 
-    var reports, result;
+    var reports;
     options = options || {};
 
     check.assert.array(modules, 'Invalid modules');
@@ -39,9 +39,9 @@ function analyse (modules, walker, options) {
     }, []);
 
     if (options.skipCalculation) {
-      return {
-        reports: reports
-      };
+        return {
+            reports: reports
+        };
     }
 
     return processResults({
@@ -50,13 +50,13 @@ function analyse (modules, walker, options) {
 }
 
 function processResults(result, noCoreSize) {
-    if (noCoreSize == null) {
+    if (noCoreSize === null) {
         noCoreSize = false;
     }
     createAdjacencyMatrix(result);
     if (!noCoreSize) {
-      createVisibilityMatrix(result);
-      setCoreSize(result);
+        createVisibilityMatrix(result);
+        setCoreSize(result);
     }
     calculateAverages(result);
 
@@ -170,13 +170,12 @@ function percentify (value, limit) {
 // implementation of floydWarshall alg for calculating visibility matrix in O(n^3) instead of O(n^4) with successive raising of powers
 function createVisibilityMatrix (result) {
 
-    var changeCost = 0;
-    var visibilityMatrix = adjacencyToDistMatrix(result.adjacencyMatrix);
-    var matrixLen = visibilityMatrix.length;
-    for (var k = 0; k < matrixLen; k++) {
-        for (var i = 0; i < matrixLen; i++) {
-            for (var j = 0; j < matrixLen; j++) {
-              visibilityMatrix[i][j] = Math.min(visibilityMatrix[i][j], visibilityMatrix[i][k] + visibilityMatrix[k][j]);
+    var changeCost = 0, visibilityMatrix = adjacencyToDistMatrix(result.adjacencyMatrix), matrixLen = visibilityMatrix.length, k, i, j;
+
+    for (k = 0; k < matrixLen; k += 1) {
+        for (i = 0; i < matrixLen; i += 1) {
+            for (j = 0; j < matrixLen; j += 1) {
+                visibilityMatrix[i][j] = Math.min(visibilityMatrix[i][j], visibilityMatrix[i][k] + visibilityMatrix[k][j]);
             }
         }
     }
@@ -203,31 +202,20 @@ function createVisibilityMatrix (result) {
 
 // where we have 0, set distance to Infinity and copy the matrix so its special
 function adjacencyToDistMatrix(matrix) {
-    var distMatrix = [];
-    for (var i = 0; i < matrix.length; i++) {
+    var distMatrix = [], i, j, value;
+    for (i = 0; i < matrix.length; i += 1) {
         distMatrix.push([]);
-        for (var j = 0; j < matrix[i].length; j++) {
-            var value = null;
-            if (i == j) {
-              value = 1
+        for (j = 0; j < matrix[i].length; j += 1) {
+            value = null;
+            if (i === j) {
+                value = 1;
             } else {
-              value = matrix[i][j] || Infinity
+                value = matrix[i][j] || Infinity;
             }
-            distMatrix[i][j] = value
+            distMatrix[i][j] = value;
         }
     }
     return distMatrix;
-}
-function emptyMatrix(size) {
-    var mat = [];
-    for (var i = 0; i < size; i++) {
-        var newRow = [];
-        for (var j = 0; j < size; i++) {
-          newRow.push(0);
-        }
-        mat.push(newRow);
-    }
-    return mat;
 }
 
 function setCoreSize (result) {

--- a/src/project.js
+++ b/src/project.js
@@ -189,8 +189,6 @@ function createVisibilityMatrix (result) {
 
                 if (columnIndex !== rowIndex) {
                     return 1;
-                } else {
-                    return 0;
                 }
             }
 

--- a/test/fixture/ast_moz.json
+++ b/test/fixture/ast_moz.json
@@ -1,0 +1,6808 @@
+{
+    "reports": [
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 41,
+                    "physical": 71
+                },
+                "cyclomatic": 8,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 101,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "if",
+                            ":?"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 51,
+                        "total": 152,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "check",
+                            "safeName",
+                            "syntaxDefinitions",
+                            "\"check-types\"",
+                            "require",
+                            "\"./safeName\"",
+                            "\"./syntax\"",
+                            "exports",
+                            "walk",
+                            "tree",
+                            "settings",
+                            "callbacks",
+                            "syntaxes",
+                            "\"Invalid syntax tree\"",
+                            "assert",
+                            "object",
+                            "body",
+                            "\"Invalid syntax tree body\"",
+                            "array",
+                            "\"Invalid settings\"",
+                            "\"Invalid callbacks\"",
+                            "processNode",
+                            "\"Invalid processNode callback\"",
+                            "function",
+                            "createScope",
+                            "\"Invalid createScope callback\"",
+                            "popScope",
+                            "\"Invalid popScope callback\"",
+                            "get",
+                            "visitNodes",
+                            "nodes",
+                            "assignedName",
+                            "<anonymous>",
+                            "node",
+                            "visitNode",
+                            "forEach",
+                            "syntax",
+                            "type",
+                            "newScope",
+                            "id",
+                            "loc",
+                            "params",
+                            "length",
+                            "visitChildren",
+                            "children",
+                            "child",
+                            "assignableName",
+                            "\"\"",
+                            "visitChild",
+                            "visitor"
+                        ]
+                    },
+                    "length": 253,
+                    "vocabulary": 58,
+                    "difficulty": 10.431372549019608,
+                    "volume": 1482.0691917672757,
+                    "effort": 15460.015882748838,
+                    "bugs": 0.49402306392242523,
+                    "time": 858.8897712638243
+                },
+                "params": 12,
+                "line": 3,
+                "cyclomaticDensity": 19.51219512195122
+            },
+            "functions": [
+                {
+                    "name": "walk",
+                    "sloc": {
+                        "logical": 14,
+                        "physical": 61
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 35,
+                            "identifiers": [
+                                "var",
+                                "()",
+                                ".",
+                                "=",
+                                "function"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 26,
+                            "total": 54,
+                            "identifiers": [
+                                "tree",
+                                "settings",
+                                "callbacks",
+                                "syntaxes",
+                                "\"Invalid syntax tree\"",
+                                "check",
+                                "assert",
+                                "object",
+                                "body",
+                                "\"Invalid syntax tree body\"",
+                                "array",
+                                "\"Invalid settings\"",
+                                "\"Invalid callbacks\"",
+                                "processNode",
+                                "\"Invalid processNode callback\"",
+                                "function",
+                                "createScope",
+                                "\"Invalid createScope callback\"",
+                                "popScope",
+                                "\"Invalid popScope callback\"",
+                                "syntaxDefinitions",
+                                "get",
+                                "visitNodes",
+                                "visitNode",
+                                "visitChildren",
+                                "visitChild"
+                            ]
+                        },
+                        "length": 89,
+                        "vocabulary": 31,
+                        "difficulty": 5.1923076923076925,
+                        "volume": 440.92347162443195,
+                        "effort": 2289.4103334345505,
+                        "bugs": 0.14697449054147732,
+                        "time": 127.18946296858614
+                    },
+                    "params": 3,
+                    "line": 13,
+                    "cyclomaticDensity": 7.142857142857142
+                },
+                {
+                    "name": "visitNodes",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 5
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "()",
+                                "function",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "nodes",
+                                "assignedName",
+                                "<anonymous>",
+                                "forEach"
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 7,
+                        "difficulty": 1.875,
+                        "volume": 22.458839376460833,
+                        "effort": 42.11032383086406,
+                        "bugs": 0.007486279792153611,
+                        "time": 2.3394624350480036
+                    },
+                    "params": 2,
+                    "line": 28,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 1,
+                            "total": 1,
+                            "identifiers": [
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "node",
+                                "assignedName",
+                                "visitNode"
+                            ]
+                        },
+                        "length": 5,
+                        "vocabulary": 4,
+                        "difficulty": 0.6666666666666666,
+                        "volume": 10,
+                        "effort": 6.666666666666666,
+                        "bugs": 0.0033333333333333335,
+                        "time": 0.37037037037037035
+                    },
+                    "params": 1,
+                    "line": 29,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "visitNode",
+                    "sloc": {
+                        "logical": 10,
+                        "physical": 21
+                    },
+                    "cyclomatic": 5,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 26,
+                            "identifiers": [
+                                "var",
+                                "if",
+                                "()",
+                                ".",
+                                "="
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 18,
+                            "total": 36,
+                            "identifiers": [
+                                "node",
+                                "assignedName",
+                                "syntax",
+                                "check",
+                                "object",
+                                "syntaxes",
+                                "type",
+                                "callbacks",
+                                "processNode",
+                                "newScope",
+                                "id",
+                                "safeName",
+                                "loc",
+                                "params",
+                                "length",
+                                "createScope",
+                                "visitChildren",
+                                "popScope"
+                            ]
+                        },
+                        "length": 62,
+                        "vocabulary": 23,
+                        "difficulty": 5,
+                        "volume": 280.4608412755348,
+                        "effort": 1402.3042063776738,
+                        "bugs": 0.09348694709184494,
+                        "time": 77.9057892432041
+                    },
+                    "params": 2,
+                    "line": 34,
+                    "cyclomaticDensity": 50
+                },
+                {
+                    "name": "visitChildren",
+                    "sloc": {
+                        "logical": 3,
+                        "physical": 12
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 6,
+                            "total": 12,
+                            "identifiers": [
+                                "var",
+                                "=",
+                                ".",
+                                "if",
+                                "()",
+                                "function"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 13,
+                            "identifiers": [
+                                "node",
+                                "syntax",
+                                "syntaxes",
+                                "type",
+                                "children",
+                                "check",
+                                "array",
+                                "<anonymous>",
+                                "forEach"
+                            ]
+                        },
+                        "length": 25,
+                        "vocabulary": 15,
+                        "difficulty": 4.333333333333333,
+                        "volume": 97.67226489021297,
+                        "effort": 423.24648119092285,
+                        "bugs": 0.03255742163007099,
+                        "time": 23.513693399495715
+                    },
+                    "params": 1,
+                    "line": 56,
+                    "cyclomaticDensity": 66.66666666666666
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 6
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 8,
+                            "identifiers": [
+                                "()",
+                                ".",
+                                ":?"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 12,
+                            "identifiers": [
+                                "child",
+                                "node",
+                                "syntax",
+                                "assignableName",
+                                "check",
+                                "function",
+                                "\"\"",
+                                "visitChild"
+                            ]
+                        },
+                        "length": 20,
+                        "vocabulary": 11,
+                        "difficulty": 2.25,
+                        "volume": 69.18863237274596,
+                        "effort": 155.6744228386784,
+                        "bugs": 0.023062877457581985,
+                        "time": 8.648579046593245
+                    },
+                    "params": 1,
+                    "line": 60,
+                    "cyclomaticDensity": 200
+                },
+                {
+                    "name": "visitChild",
+                    "sloc": {
+                        "logical": 2,
+                        "physical": 4
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                "var",
+                                "=",
+                                ":?",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 11,
+                            "identifiers": [
+                                "child",
+                                "assignedName",
+                                "visitor",
+                                "check",
+                                "array",
+                                "visitNodes",
+                                "visitNode"
+                            ]
+                        },
+                        "length": 17,
+                        "vocabulary": 12,
+                        "difficulty": 3.9285714285714284,
+                        "volume": 60.94436251225966,
+                        "effort": 239.42428129816292,
+                        "bugs": 0.020314787504086555,
+                        "time": 13.301348961009051
+                    },
+                    "params": 2,
+                    "line": 69,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 7,
+                    "path": "check-types",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 8,
+                    "path": "./safeName",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 9,
+                    "path": "./syntax",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 124.06151779557825,
+            "loc": 4.571428571428571,
+            "cyclomatic": 2,
+            "effort": 651.2623879482171,
+            "params": 1.7142857142857142,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/index.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 8,
+                    "physical": 15
+                },
+                "cyclomatic": 3,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 20,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "if",
+                            "&&",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 12,
+                        "total": 23,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "check",
+                            "\"check-types\"",
+                            "require",
+                            "module",
+                            "exports",
+                            "<anonymous>",
+                            "object",
+                            "defaultName",
+                            "name",
+                            "unemptyString",
+                            "\"<anonymous>\""
+                        ]
+                    },
+                    "length": 43,
+                    "vocabulary": 20,
+                    "difficulty": 7.666666666666667,
+                    "volume": 185.8429080801566,
+                    "effort": 1424.795628614534,
+                    "bugs": 0.06194763602671887,
+                    "time": 79.15531270080744
+                },
+                "params": 2,
+                "line": 3,
+                "cyclomaticDensity": 37.5
+            },
+            "functions": [
+                {
+                    "name": "module.exports",
+                    "sloc": {
+                        "logical": 5,
+                        "physical": 11
+                    },
+                    "cyclomatic": 3,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 14,
+                            "identifiers": [
+                                "if",
+                                "&&",
+                                "()",
+                                ".",
+                                "return"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 16,
+                            "identifiers": [
+                                "object",
+                                "defaultName",
+                                "check",
+                                "name",
+                                "unemptyString",
+                                "\"<anonymous>\""
+                            ]
+                        },
+                        "length": 30,
+                        "vocabulary": 11,
+                        "difficulty": 6.666666666666666,
+                        "volume": 103.78294855911894,
+                        "effort": 691.8863237274595,
+                        "bugs": 0.03459431618637298,
+                        "time": 38.43812909596997
+                    },
+                    "params": 2,
+                    "line": 7,
+                    "cyclomaticDensity": 60
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "check-types",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 122.30960288059134,
+            "loc": 5,
+            "cyclomatic": 3,
+            "effort": 691.8863237274595,
+            "params": 2,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/safeName.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 6,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 11,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "\"[]\"",
+                            "\"../safeName\"",
+                            "\"elements\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 17,
+                    "difficulty": 4.363636363636363,
+                    "volume": 106.27403387250884,
+                    "effort": 463.74123871640217,
+                    "bugs": 0.03542467795750295,
+                    "time": 25.763402150911233
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 8,
+                            "identifiers": [
+                                0,
+                                "\"[]\"",
+                                "\"../safeName\"",
+                                "require",
+                                "\"elements\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 10,
+                        "difficulty": 1.7142857142857142,
+                        "volume": 39.863137138648355,
+                        "effort": 68.33680652339717,
+                        "bugs": 0.013287712379549451,
+                        "time": 3.796489251299843
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 10,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 156.55238607408194,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 68.33680652339717,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ArrayExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 10,
+                    "physical": 23
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 10,
+                        "total": 33,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]",
+                            "if",
+                            "===",
+                            "+"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 24,
+                        "total": 42,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "safeName",
+                            "\"../safeName\"",
+                            "exports",
+                            "get",
+                            0,
+                            "<anonymous>",
+                            "node",
+                            "operator",
+                            "undefined",
+                            "\"left\"",
+                            "\"right\"",
+                            "left",
+                            "type",
+                            "\"MemberExpression\"",
+                            "object",
+                            "\".\"",
+                            "property",
+                            "name",
+                            "id",
+                            "actualise"
+                        ]
+                    },
+                    "length": 75,
+                    "vocabulary": 34,
+                    "difficulty": 8.75,
+                    "volume": 381.5597130937755,
+                    "effort": 3338.6474895705355,
+                    "bugs": 0.1271865710312585,
+                    "time": 185.48041608725197
+                },
+                "params": 2,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 16
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 10,
+                            "identifiers": [
+                                0,
+                                "<anonymous>",
+                                "undefined",
+                                "\"left\"",
+                                "\"right\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 12,
+                        "difficulty": 3.5714285714285716,
+                        "volume": 57.359400011538504,
+                        "effort": 204.85500004120897,
+                        "bugs": 0.01911980000384617,
+                        "time": 11.38083333562272
+                    },
+                    "params": 0,
+                    "line": 10,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 2,
+                            "identifiers": [
+                                "return",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "operator"
+                            ]
+                        },
+                        "length": 5,
+                        "vocabulary": 4,
+                        "difficulty": 1.5,
+                        "volume": 10,
+                        "effort": 15,
+                        "bugs": 0.0033333333333333335,
+                        "time": 0.8333333333333334
+                    },
+                    "params": 1,
+                    "line": 13,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 3,
+                        "physical": 7
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 6,
+                            "total": 17,
+                            "identifiers": [
+                                "if",
+                                "===",
+                                ".",
+                                "return",
+                                "+",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 10,
+                            "total": 18,
+                            "identifiers": [
+                                "node",
+                                "left",
+                                "type",
+                                "\"MemberExpression\"",
+                                "object",
+                                "safeName",
+                                "\".\"",
+                                "property",
+                                "name",
+                                "id"
+                            ]
+                        },
+                        "length": 35,
+                        "vocabulary": 16,
+                        "difficulty": 5.4,
+                        "volume": 140,
+                        "effort": 756,
+                        "bugs": 0.04666666666666667,
+                        "time": 42
+                    },
+                    "params": 1,
+                    "line": 17,
+                    "cyclomaticDensity": 66.66666666666666
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 6,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 142.87477813190347,
+            "loc": 1.6666666666666667,
+            "cyclomatic": 1.3333333333333333,
+            "effort": 325.28500001373635,
+            "params": 0.6666666666666666,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/AssignmentExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 13,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 14,
+                        "total": 20,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "<anonymous>",
+                            "node",
+                            "operator",
+                            "undefined",
+                            "\"left\"",
+                            "\"right\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 33,
+                    "vocabulary": 21,
+                    "difficulty": 5,
+                    "volume": 144.94647495169912,
+                    "effort": 724.7323747584956,
+                    "bugs": 0.048315491650566374,
+                    "time": 40.26290970880531
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 16.666666666666664
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 9,
+                            "identifiers": [
+                                0,
+                                "<anonymous>",
+                                "undefined",
+                                "\"left\"",
+                                "\"right\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 12,
+                        "difficulty": 3.2142857142857144,
+                        "volume": 50.18947501009619,
+                        "effort": 161.32331253245204,
+                        "bugs": 0.016729825003365395,
+                        "time": 8.962406251802891
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 2,
+                            "identifiers": [
+                                "return",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "operator"
+                            ]
+                        },
+                        "length": 5,
+                        "vocabulary": 4,
+                        "difficulty": 1.5,
+                        "volume": 10,
+                        "effort": 15,
+                        "bugs": 0.0033333333333333335,
+                        "time": 0.8333333333333334
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.68123130761276,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 88.16165626622602,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/BinaryExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 6,
+                        "total": 9,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 10,
+                        "total": 15,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "undefined",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 24,
+                    "vocabulary": 16,
+                    "difficulty": 4.5,
+                    "volume": 96,
+                    "effort": 432,
+                    "bugs": 0.032,
+                    "time": 24
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 7,
+                            "identifiers": [
+                                0,
+                                "undefined",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 10,
+                        "vocabulary": 8,
+                        "difficulty": 2.0999999999999996,
+                        "volume": 30,
+                        "effort": 62.999999999999986,
+                        "bugs": 0.01,
+                        "time": 3.499999999999999
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 156.83047923574097,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 62.999999999999986,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/BlockStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 13,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"break\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"label\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 20,
+                    "difficulty": 4.307692307692308,
+                    "volume": 112.37013046707143,
+                    "effort": 484.05594662738474,
+                    "bugs": 0.03745671015569048,
+                    "time": 26.891997034854707
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 8,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"break\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"label\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 12,
+                        "difficulty": 2,
+                        "volume": 43.01955000865388,
+                        "effort": 86.03910001730776,
+                        "bugs": 0.014339850002884626,
+                        "time": 4.779950000961542
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.76457769251132,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 86.03910001730776,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/BreakStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 50,
+                    "physical": 106
+                },
+                "cyclomatic": 15,
+                "halstead": {
+                    "operators": {
+                        "distinct": 15,
+                        "total": 176,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            "{}",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "===",
+                            "[]",
+                            "if",
+                            "&&",
+                            "typeof (prefix)",
+                            ":",
+                            "||"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 66,
+                        "total": 216,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "amdPathAliases",
+                            "<anonymous>",
+                            "exports",
+                            "get",
+                            "node",
+                            "callee",
+                            "type",
+                            "\"FunctionExpression\"",
+                            1,
+                            0,
+                            "\"()\"",
+                            "undefined",
+                            "\"arguments\"",
+                            "\"callee\"",
+                            "clearAliases",
+                            "\"Identifier\"",
+                            "name",
+                            "\"require\"",
+                            "processRequire",
+                            "\"MemberExpression\"",
+                            "object",
+                            "property",
+                            "\"config\"",
+                            "arguments",
+                            "processAmdRequireConfig",
+                            "actualise",
+                            "length",
+                            "processCommonJsRequire",
+                            2,
+                            "processAmdRequire",
+                            "resolveRequireDependency",
+                            "\"CommonJS\"",
+                            "createDependency",
+                            "dependency",
+                            "resolver",
+                            "\"Literal\"",
+                            "\"function\"",
+                            "value",
+                            "\"* dynamic dependency *\"",
+                            "path",
+                            "line",
+                            "loc",
+                            "start",
+                            "\"ArrayExpression\"",
+                            null,
+                            "processAmdRequireItem",
+                            "bind",
+                            "elements",
+                            "map",
+                            "\"* dynamic dependencies *\"",
+                            "\"AMD\"",
+                            "item",
+                            "resolveAmdRequireDependency",
+                            "args",
+                            "\"ObjectExpression\"",
+                            "processAmdRequireConfigProperty",
+                            "properties",
+                            "forEach",
+                            "key",
+                            "\"paths\"",
+                            "setAmdPathAlias",
+                            "alias"
+                        ]
+                    },
+                    "length": 392,
+                    "vocabulary": 81,
+                    "difficulty": 24.545454545454547,
+                    "volume": 2485.221201130773,
+                    "effort": 61000.88402775534,
+                    "bugs": 0.828407067043591,
+                    "time": 3388.9380015419633
+                },
+                "params": 17,
+                "line": 3,
+                "cyclomaticDensity": 30
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 28
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 12,
+                            "identifiers": [
+                                "<anonymous>",
+                                0,
+                                "\"()\"",
+                                "undefined",
+                                "\"arguments\"",
+                                "\"callee\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 18,
+                        "vocabulary": 13,
+                        "difficulty": 3.75,
+                        "volume": 66.60791492653966,
+                        "effort": 249.77968097452373,
+                        "bugs": 0.022202638308846556,
+                        "time": 13.876648943029096
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "===",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 7,
+                            "identifiers": [
+                                "node",
+                                "callee",
+                                "type",
+                                "\"FunctionExpression\"",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 10,
+                        "difficulty": 2.3333333333333335,
+                        "volume": 39.863137138648355,
+                        "effort": 93.01398665684617,
+                        "bugs": 0.013287712379549451,
+                        "time": 5.167443703158121
+                    },
+                    "params": 1,
+                    "line": 11,
+                    "cyclomaticDensity": 200
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 6,
+                        "physical": 20
+                    },
+                    "cyclomatic": 4,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 8,
+                            "total": 39,
+                            "identifiers": [
+                                "if",
+                                "=",
+                                "{}",
+                                "&&",
+                                "===",
+                                ".",
+                                "return",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 16,
+                            "total": 42,
+                            "identifiers": [
+                                "node",
+                                "clearAliases",
+                                "amdPathAliases",
+                                "<anonymous>",
+                                "callee",
+                                "type",
+                                "\"Identifier\"",
+                                "name",
+                                "\"require\"",
+                                "processRequire",
+                                "\"MemberExpression\"",
+                                "object",
+                                "property",
+                                "\"config\"",
+                                "arguments",
+                                "processAmdRequireConfig"
+                            ]
+                        },
+                        "length": 81,
+                        "vocabulary": 24,
+                        "difficulty": 10.5,
+                        "volume": 371.3819625584137,
+                        "effort": 3899.510606863344,
+                        "bugs": 0.12379398751947124,
+                        "time": 216.63947815907466
+                    },
+                    "params": 2,
+                    "line": 15,
+                    "cyclomaticDensity": 66.66666666666666
+                },
+                {
+                    "name": "processRequire",
+                    "sloc": {
+                        "logical": 4,
+                        "physical": 9
+                    },
+                    "cyclomatic": 3,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 12,
+                            "identifiers": [
+                                "if",
+                                "===",
+                                ".",
+                                "return",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 13,
+                            "identifiers": [
+                                "node",
+                                "arguments",
+                                "length",
+                                1,
+                                "processCommonJsRequire",
+                                2,
+                                "processAmdRequire"
+                            ]
+                        },
+                        "length": 25,
+                        "vocabulary": 12,
+                        "difficulty": 4.642857142857143,
+                        "volume": 89.62406251802891,
+                        "effort": 416.11171883370565,
+                        "bugs": 0.029874687506009637,
+                        "time": 23.11731771298365
+                    },
+                    "params": 1,
+                    "line": 38,
+                    "cyclomaticDensity": 75
+                },
+                {
+                    "name": "processCommonJsRequire",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 8,
+                            "identifiers": [
+                                "node",
+                                "arguments",
+                                0,
+                                "resolveRequireDependency",
+                                "\"CommonJS\"",
+                                "createDependency"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 9,
+                        "difficulty": 2,
+                        "volume": 41.20902501875006,
+                        "effort": 82.41805003750012,
+                        "bugs": 0.013736341672916687,
+                        "time": 4.578780557638896
+                    },
+                    "params": 1,
+                    "line": 48,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "resolveRequireDependency",
+                    "sloc": {
+                        "logical": 5,
+                        "physical": 11
+                    },
+                    "cyclomatic": 3,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 6,
+                            "total": 12,
+                            "identifiers": [
+                                "if",
+                                "===",
+                                ".",
+                                "typeof (prefix)",
+                                "return",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 13,
+                            "identifiers": [
+                                "dependency",
+                                "resolver",
+                                "type",
+                                "\"Literal\"",
+                                "\"function\"",
+                                "value",
+                                "\"* dynamic dependency *\""
+                            ]
+                        },
+                        "length": 25,
+                        "vocabulary": 13,
+                        "difficulty": 5.571428571428571,
+                        "volume": 92.5109929535273,
+                        "effort": 515.4183893125092,
+                        "bugs": 0.030836997651175767,
+                        "time": 28.634354961806068
+                    },
+                    "params": 2,
+                    "line": 52,
+                    "cyclomaticDensity": 60
+                },
+                {
+                    "name": "createDependency",
+                    "sloc": {
+                        "logical": 4,
+                        "physical": 7
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 8,
+                            "identifiers": [
+                                "return",
+                                "{}",
+                                ":",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 13,
+                            "identifiers": [
+                                "node",
+                                "path",
+                                "type",
+                                "<anonymous>",
+                                "line",
+                                "loc",
+                                "start"
+                            ]
+                        },
+                        "length": 21,
+                        "vocabulary": 11,
+                        "difficulty": 3.7142857142857144,
+                        "volume": 72.64806399138325,
+                        "effort": 269.83566625370923,
+                        "bugs": 0.024216021330461083,
+                        "time": 14.990870347428292
+                    },
+                    "params": 3,
+                    "line": 64,
+                    "cyclomaticDensity": 25
+                },
+                {
+                    "name": "processAmdRequire",
+                    "sloc": {
+                        "logical": 5,
+                        "physical": 11
+                    },
+                    "cyclomatic": 3,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 24,
+                            "identifiers": [
+                                "if",
+                                "===",
+                                ".",
+                                "return",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 14,
+                            "total": 29,
+                            "identifiers": [
+                                "node",
+                                "arguments",
+                                0,
+                                "type",
+                                "\"ArrayExpression\"",
+                                null,
+                                "processAmdRequireItem",
+                                "bind",
+                                "elements",
+                                "map",
+                                "\"Literal\"",
+                                "\"* dynamic dependencies *\"",
+                                "\"AMD\"",
+                                "createDependency"
+                            ]
+                        },
+                        "length": 53,
+                        "vocabulary": 19,
+                        "difficulty": 5.178571428571429,
+                        "volume": 225.14015821251002,
+                        "effort": 1165.9043907433554,
+                        "bugs": 0.07504671940417,
+                        "time": 64.77246615240864
+                    },
+                    "params": 1,
+                    "line": 72,
+                    "cyclomaticDensity": 60
+                },
+                {
+                    "name": "processAmdRequireItem",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 8,
+                            "identifiers": [
+                                "node",
+                                "item",
+                                "resolveAmdRequireDependency",
+                                "resolveRequireDependency",
+                                "\"AMD\"",
+                                "createDependency"
+                            ]
+                        },
+                        "length": 11,
+                        "vocabulary": 8,
+                        "difficulty": 1.3333333333333333,
+                        "volume": 33,
+                        "effort": 44,
+                        "bugs": 0.011,
+                        "time": 2.4444444444444446
+                    },
+                    "params": 2,
+                    "line": 84,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "resolveAmdRequireDependency",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "||",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 4,
+                            "identifiers": [
+                                "dependency",
+                                "amdPathAliases"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 5,
+                        "difficulty": 3,
+                        "volume": 16.253496664211536,
+                        "effort": 48.760489992634604,
+                        "bugs": 0.005417832221403845,
+                        "time": 2.7089161107019226
+                    },
+                    "params": 1,
+                    "line": 88,
+                    "cyclomaticDensity": 200
+                },
+                {
+                    "name": "processAmdRequireConfig",
+                    "sloc": {
+                        "logical": 2,
+                        "physical": 5
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 11,
+                            "identifiers": [
+                                "if",
+                                "&&",
+                                "===",
+                                ".",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 13,
+                            "identifiers": [
+                                "args",
+                                "length",
+                                1,
+                                0,
+                                "type",
+                                "\"ObjectExpression\"",
+                                "processAmdRequireConfigProperty",
+                                "properties",
+                                "forEach"
+                            ]
+                        },
+                        "length": 24,
+                        "vocabulary": 14,
+                        "difficulty": 3.611111111111111,
+                        "volume": 91.37651812938249,
+                        "effort": 329.970759911659,
+                        "bugs": 0.03045883937646083,
+                        "time": 18.331708883981054
+                    },
+                    "params": 1,
+                    "line": 92,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "processAmdRequireConfigProperty",
+                    "sloc": {
+                        "logical": 2,
+                        "physical": 5
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 16,
+                            "identifiers": [
+                                "if",
+                                "&&",
+                                "===",
+                                ".",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 11,
+                            "total": 18,
+                            "identifiers": [
+                                "property",
+                                "key",
+                                "type",
+                                "\"Identifier\"",
+                                "name",
+                                "\"paths\"",
+                                "value",
+                                "\"ObjectExpression\"",
+                                "setAmdPathAlias",
+                                "properties",
+                                "forEach"
+                            ]
+                        },
+                        "length": 34,
+                        "vocabulary": 16,
+                        "difficulty": 4.090909090909091,
+                        "volume": 136,
+                        "effort": 556.3636363636364,
+                        "bugs": 0.04533333333333334,
+                        "time": 30.90909090909091
+                    },
+                    "params": 1,
+                    "line": 98,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "setAmdPathAlias",
+                    "sloc": {
+                        "logical": 2,
+                        "physical": 5
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 14,
+                            "identifiers": [
+                                "if",
+                                "&&",
+                                "===",
+                                ".",
+                                "="
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 16,
+                            "identifiers": [
+                                "alias",
+                                "key",
+                                "type",
+                                "\"Identifier\"",
+                                "value",
+                                "\"Literal\"",
+                                "amdPathAliases",
+                                "name"
+                            ]
+                        },
+                        "length": 30,
+                        "vocabulary": 13,
+                        "difficulty": 5,
+                        "volume": 111.01319154423277,
+                        "effort": 555.0659577211638,
+                        "bugs": 0.03700439718141092,
+                        "time": 30.836997651175768
+                    },
+                    "params": 1,
+                    "line": 104,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 132.7280113128071,
+            "loc": 2.6923076923076925,
+            "cyclomatic": 2.076923076923077,
+            "effort": 632.7810256665068,
+            "params": 1.3076923076923077,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/CallExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 14,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 16,
+                        "total": 22,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "settings",
+                            1,
+                            "<anonymous>",
+                            "trycatch",
+                            0,
+                            "\"catch\"",
+                            "undefined",
+                            "\"param\"",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 36,
+                    "vocabulary": 24,
+                    "difficulty": 5.5,
+                    "volume": 165.05865002596164,
+                    "effort": 907.822575142789,
+                    "bugs": 0.05501955000865388,
+                    "time": 50.43458750793272
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 10,
+                            "identifiers": [
+                                "settings",
+                                1,
+                                "<anonymous>",
+                                "\"catch\"",
+                                "undefined",
+                                "\"param\"",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 15,
+                        "vocabulary": 14,
+                        "difficulty": 2.7777777777777777,
+                        "volume": 57.110323830864054,
+                        "effort": 158.6397884190668,
+                        "bugs": 0.019036774610288017,
+                        "time": 8.813321578837044
+                    },
+                    "params": 1,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "settings",
+                                "trycatch",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 7,
+                        "difficulty": 1.5,
+                        "volume": 19.651484454403228,
+                        "effort": 29.47722668160484,
+                        "bugs": 0.00655049481813441,
+                        "time": 1.6376237045336022
+                    },
+                    "params": 0,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.36654685300488,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 94.05850755033582,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/CatchClause.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 15,
+                        "total": 18,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            1,
+                            "\":?\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"test\"",
+                            "\"consequent\"",
+                            "\"alternate\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 28,
+                    "vocabulary": 22,
+                    "difficulty": 4.2,
+                    "volume": 124.86408532184433,
+                    "effort": 524.4291583517462,
+                    "bugs": 0.04162136177394811,
+                    "time": 29.13495324176368
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 10,
+                            "total": 10,
+                            "identifiers": [
+                                0,
+                                1,
+                                "\":?\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"test\"",
+                                "\"consequent\"",
+                                "\"alternate\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 14,
+                        "difficulty": 2,
+                        "volume": 53.30296890880645,
+                        "effort": 106.6059378176129,
+                        "bugs": 0.017767656302935482,
+                        "time": 5.9225521009784945
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.0315438948429,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 106.6059378176129,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ConditionalExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 13,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"continue\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"label\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 20,
+                    "difficulty": 4.307692307692308,
+                    "volume": 112.37013046707143,
+                    "effort": 484.05594662738474,
+                    "bugs": 0.03745671015569048,
+                    "time": 26.891997034854707
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 8,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"continue\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"label\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 12,
+                        "difficulty": 2,
+                        "volume": 43.01955000865388,
+                        "effort": 86.03910001730776,
+                        "bugs": 0.014339850002884626,
+                        "time": 4.779950000961542
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.76457769251132,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 86.03910001730776,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ContinueStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 14,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 17,
+                        "total": 22,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            2,
+                            "<anonymous>",
+                            "node",
+                            "test",
+                            1,
+                            0,
+                            "\"dowhile\"",
+                            "undefined",
+                            "\"test\"",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 36,
+                    "vocabulary": 25,
+                    "difficulty": 5.176470588235294,
+                    "volume": 167.17882283189007,
+                    "effort": 865.3962593650781,
+                    "bugs": 0.05572627427729669,
+                    "time": 48.077569964726564
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 9,
+                            "identifiers": [
+                                2,
+                                "<anonymous>",
+                                "\"dowhile\"",
+                                "undefined",
+                                "\"test\"",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 13,
+                        "difficulty": 2.8125,
+                        "volume": 51.80615605397529,
+                        "effort": 145.70481390180552,
+                        "bugs": 0.01726871868465843,
+                        "time": 8.09471188343364
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "node",
+                                "test",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 7,
+                        "difficulty": 1.875,
+                        "volume": 22.458839376460833,
+                        "effort": 42.11032383086406,
+                        "bugs": 0.007486279792153611,
+                        "time": 2.3394624350480036
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.3720394442222,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 93.9075688663348,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/DoWhileStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 12,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "undefined",
+                            "<anonymous>",
+                            "\"expression\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 19,
+                    "difficulty": 4.666666666666666,
+                    "volume": 110.44611534953322,
+                    "effort": 515.4152049644882,
+                    "bugs": 0.03681537178317774,
+                    "time": 28.63417805358268
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 8,
+                            "identifiers": [
+                                1,
+                                0,
+                                "undefined",
+                                "<anonymous>",
+                                "\"expression\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 11,
+                        "difficulty": 2.2857142857142856,
+                        "volume": 41.51317942364757,
+                        "effort": 94.88726725405158,
+                        "bugs": 0.01383772647454919,
+                        "time": 5.27151484744731
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.42980181944586,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 94.88726725405158,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ExpressionStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 14,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 17,
+                        "total": 23,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "settings",
+                            1,
+                            "<anonymous>",
+                            "forin",
+                            0,
+                            "\"forin\"",
+                            "undefined",
+                            "\"left\"",
+                            "\"right\"",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 37,
+                    "vocabulary": 25,
+                    "difficulty": 5.411764705882353,
+                    "volume": 171.8226790216648,
+                    "effort": 929.8639099995978,
+                    "bugs": 0.057274226340554936,
+                    "time": 51.65910611108877
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 10,
+                            "total": 11,
+                            "identifiers": [
+                                "settings",
+                                1,
+                                "<anonymous>",
+                                "\"forin\"",
+                                "undefined",
+                                "\"left\"",
+                                "\"right\"",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 15,
+                        "difficulty": 2.75,
+                        "volume": 62.5102495297363,
+                        "effort": 171.90318620677482,
+                        "bugs": 0.020836749843245433,
+                        "time": 9.55017701148749
+                    },
+                    "params": 1,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "settings",
+                                "forin",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 7,
+                        "difficulty": 1.5,
+                        "volume": 19.651484454403228,
+                        "effort": 29.47722668160484,
+                        "bugs": 0.00655049481813441,
+                        "time": 1.6376237045336022
+                    },
+                    "params": 0,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.13353701758174,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 100.69020644418983,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ForInStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 14,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 24,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            "<anonymous>",
+                            "node",
+                            "test",
+                            0,
+                            "\"for\"",
+                            "undefined",
+                            "\"init\"",
+                            "\"test\"",
+                            "\"update\"",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 38,
+                    "vocabulary": 26,
+                    "difficulty": 5.333333333333333,
+                    "volume": 178.61670928936152,
+                    "effort": 952.6224495432614,
+                    "bugs": 0.05953890309645384,
+                    "time": 52.923469419070074
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 10,
+                            "total": 11,
+                            "identifiers": [
+                                1,
+                                "<anonymous>",
+                                "\"for\"",
+                                "undefined",
+                                "\"init\"",
+                                "\"test\"",
+                                "\"update\"",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 15,
+                        "difficulty": 2.75,
+                        "volume": 62.5102495297363,
+                        "effort": 171.90318620677482,
+                        "bugs": 0.020836749843245433,
+                        "time": 9.55017701148749
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "node",
+                                "test",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 7,
+                        "difficulty": 1.875,
+                        "volume": 22.458839376460833,
+                        "effort": 42.11032383086406,
+                        "bugs": 0.007486279792153611,
+                        "time": 2.3394624350480036
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 154.9254525100122,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 107.00675501881943,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ForStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 7,
+                    "physical": 16
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 16,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 19,
+                        "total": 26,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "safeName",
+                            "\"../safeName\"",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"function\"",
+                            "<anonymous>",
+                            "node",
+                            "id",
+                            "\"params\"",
+                            "\"body\"",
+                            "undefined",
+                            true,
+                            "actualise"
+                        ]
+                    },
+                    "length": 42,
+                    "vocabulary": 26,
+                    "difficulty": 4.7894736842105265,
+                    "volume": 197.4184681619259,
+                    "effort": 945.5305580386977,
+                    "bugs": 0.0658061560539753,
+                    "time": 52.52947544659432
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 14.285714285714285
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 10,
+                            "total": 11,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"function\"",
+                                "<anonymous>",
+                                "\"params\"",
+                                "\"body\"",
+                                "undefined",
+                                true,
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 15,
+                        "difficulty": 2.75,
+                        "volume": 62.5102495297363,
+                        "effort": 171.90318620677482,
+                        "bugs": 0.020836749843245433,
+                        "time": 9.55017701148749
+                    },
+                    "params": 0,
+                    "line": 10,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "node",
+                                "id",
+                                "safeName"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 6,
+                        "difficulty": 2,
+                        "volume": 18.094737505048094,
+                        "effort": 36.18947501009619,
+                        "bugs": 0.006031579168349364,
+                        "time": 2.0105263894497885
+                    },
+                    "params": 1,
+                    "line": 13,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 6,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.11465989996054,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 104.04633060843551,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/FunctionDeclaration.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 7,
+                    "physical": 16
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 16,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 26,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "safeName",
+                            "\"../safeName\"",
+                            "exports",
+                            "get",
+                            0,
+                            "\"function\"",
+                            "<anonymous>",
+                            "node",
+                            "id",
+                            "\"params\"",
+                            "\"body\"",
+                            "undefined",
+                            true,
+                            "actualise"
+                        ]
+                    },
+                    "length": 42,
+                    "vocabulary": 25,
+                    "difficulty": 5.055555555555555,
+                    "volume": 195.04195997053841,
+                    "effort": 986.0454642954998,
+                    "bugs": 0.06501398665684614,
+                    "time": 54.78030357197221
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 14.285714285714285
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 11,
+                            "identifiers": [
+                                0,
+                                "\"function\"",
+                                "<anonymous>",
+                                "\"params\"",
+                                "\"body\"",
+                                "undefined",
+                                true,
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 14,
+                        "difficulty": 3.055555555555556,
+                        "volume": 60.91767875292166,
+                        "effort": 186.13735174503842,
+                        "bugs": 0.020305892917640553,
+                        "time": 10.340963985835467
+                    },
+                    "params": 0,
+                    "line": 10,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "node",
+                                "id",
+                                "safeName"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 6,
+                        "difficulty": 2,
+                        "volume": 18.094737505048094,
+                        "effort": 36.18947501009619,
+                        "bugs": 0.006031579168349364,
+                        "time": 2.0105263894497885
+                    },
+                    "params": 1,
+                    "line": 13,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 6,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 154.88837551538842,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 111.16341337756731,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/FunctionExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 14
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 6,
+                        "total": 12,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 12,
+                        "total": 17,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "undefined",
+                            "<anonymous>",
+                            "node",
+                            "name",
+                            "actualise"
+                        ]
+                    },
+                    "length": 29,
+                    "vocabulary": 18,
+                    "difficulty": 4.25,
+                    "volume": 120.92782504182705,
+                    "effort": 513.9432564277649,
+                    "bugs": 0.04030927501394235,
+                    "time": 28.55240313487583
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 16.666666666666664
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 8
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                0,
+                                "undefined",
+                                "<anonymous>",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 10,
+                        "vocabulary": 9,
+                        "difficulty": 2.4,
+                        "volume": 31.699250014423125,
+                        "effort": 76.07820003461549,
+                        "bugs": 0.010566416671474375,
+                        "time": 4.22656666858975
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 2,
+                            "identifiers": [
+                                "return",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "name"
+                            ]
+                        },
+                        "length": 5,
+                        "vocabulary": 4,
+                        "difficulty": 1.5,
+                        "volume": 10,
+                        "effort": 15,
+                        "bugs": 0.0033333333333333335,
+                        "time": 0.8333333333333334
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 157.94048616092715,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 45.539100017307746,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/Identifier.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 9,
+                    "physical": 24
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 11,
+                        "total": 23,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "[]",
+                            "{}",
+                            ":",
+                            "! (prefix)"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 20,
+                        "total": 32,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "<anonymous>",
+                            "node",
+                            "alternate",
+                            2,
+                            1,
+                            "\"if\"",
+                            "identifier",
+                            "\"else\"",
+                            "filter",
+                            "undefined",
+                            "\"test\"",
+                            "\"consequent\"",
+                            "\"alternate\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 55,
+                    "vocabulary": 31,
+                    "difficulty": 8.8,
+                    "volume": 272.4807970712782,
+                    "effort": 2397.831014227248,
+                    "bugs": 0.09082693235709273,
+                    "time": 133.212834123736
+                },
+                "params": 2,
+                "line": 3,
+                "cyclomaticDensity": 22.22222222222222
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 3,
+                        "physical": 18
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 7,
+                            "total": 10,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "{}",
+                                ":",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 12,
+                            "total": 16,
+                            "identifiers": [
+                                "<anonymous>",
+                                1,
+                                "\"if\"",
+                                "identifier",
+                                "\"else\"",
+                                "filter",
+                                "undefined",
+                                "\"test\"",
+                                "\"consequent\"",
+                                "\"alternate\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 26,
+                        "vocabulary": 19,
+                        "difficulty": 4.666666666666666,
+                        "volume": 110.44611534953322,
+                        "effort": 515.4152049644882,
+                        "bugs": 0.03681537178317774,
+                        "time": 28.63417805358268
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 33.33333333333333
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "node",
+                                "alternate",
+                                2,
+                                1
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 7,
+                        "difficulty": 1.875,
+                        "volume": 22.458839376460833,
+                        "effort": 42.11032383086406,
+                        "bugs": 0.007486279792153611,
+                        "time": 2.3394624350480036
+                    },
+                    "params": 1,
+                    "line": 11,
+                    "cyclomaticDensity": 200
+                },
+                {
+                    "name": "filter",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "! (prefix)",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "alternate"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 5,
+                        "difficulty": 2.25,
+                        "volume": 16.253496664211536,
+                        "effort": 36.57036749447595,
+                        "bugs": 0.005417832221403845,
+                        "time": 2.031687083026442
+                    },
+                    "params": 1,
+                    "line": 19,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 144.57203268776175,
+            "loc": 1.6666666666666667,
+            "cyclomatic": 1.3333333333333333,
+            "effort": 198.03196542994274,
+            "params": 0.6666666666666666,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/IfStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 9,
+                    "physical": 20
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 22,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "if",
+                            "+"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 16,
+                        "total": 28,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "check",
+                            "\"check-types\"",
+                            "exports",
+                            "get",
+                            0,
+                            "undefined",
+                            "<anonymous>",
+                            "node",
+                            "value",
+                            "string",
+                            "\"\"\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 50,
+                    "vocabulary": 24,
+                    "difficulty": 7,
+                    "volume": 229.24812503605784,
+                    "effort": 1604.7368752524048,
+                    "bugs": 0.07641604167868594,
+                    "time": 89.1520486251336
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 22.22222222222222
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 13
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                0,
+                                "undefined",
+                                "<anonymous>",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 10,
+                        "vocabulary": 9,
+                        "difficulty": 2.4,
+                        "volume": 31.699250014423125,
+                        "effort": 76.07820003461549,
+                        "bugs": 0.010566416671474375,
+                        "time": 4.22656666858975
+                    },
+                    "params": 0,
+                    "line": 10,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 3,
+                        "physical": 8
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 10,
+                            "identifiers": [
+                                "if",
+                                "()",
+                                ".",
+                                "return",
+                                "+"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 11,
+                            "identifiers": [
+                                "node",
+                                "value",
+                                "check",
+                                "string",
+                                "\"\"\""
+                            ]
+                        },
+                        "length": 21,
+                        "vocabulary": 10,
+                        "difficulty": 5.5,
+                        "volume": 69.76048999263462,
+                        "effort": 383.6826949594904,
+                        "bugs": 0.02325349666421154,
+                        "time": 21.315705275527243
+                    },
+                    "params": 1,
+                    "line": 13,
+                    "cyclomaticDensity": 66.66666666666666
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 6,
+                    "path": "check-types",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 141.08130561946314,
+            "loc": 2,
+            "cyclomatic": 1.5,
+            "effort": 229.88044749705296,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/Literal.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 7,
+                    "physical": 18
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 10,
+                        "total": 20,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "&&",
+                            "===",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 29,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "settings",
+                            0,
+                            "<anonymous>",
+                            "node",
+                            "logicalor",
+                            "operator",
+                            "\"||\"",
+                            1,
+                            "undefined",
+                            "\"left\"",
+                            "\"right\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 49,
+                    "vocabulary": 28,
+                    "difficulty": 8.055555555555555,
+                    "volume": 235.5603911808226,
+                    "effort": 1897.5698178455152,
+                    "bugs": 0.07852013039360753,
+                    "time": 105.42054543586195
+                },
+                "params": 3,
+                "line": 3,
+                "cyclomaticDensity": 28.57142857142857
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 12
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 10,
+                            "identifiers": [
+                                "settings",
+                                0,
+                                "<anonymous>",
+                                "undefined",
+                                "\"left\"",
+                                "\"right\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 13,
+                        "difficulty": 3.125,
+                        "volume": 59.207035490257475,
+                        "effort": 185.0219859070546,
+                        "bugs": 0.019735678496752493,
+                        "time": 10.27899921705859
+                    },
+                    "params": 1,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "&&",
+                                ".",
+                                "==="
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 8,
+                            "identifiers": [
+                                "node",
+                                "settings",
+                                "logicalor",
+                                "operator",
+                                "\"||\"",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 12,
+                        "difficulty": 2.8571428571428568,
+                        "volume": 50.18947501009619,
+                        "effort": 143.39850002884623,
+                        "bugs": 0.016729825003365395,
+                        "time": 7.966583334935901
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 2,
+                            "identifiers": [
+                                "return",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "operator"
+                            ]
+                        },
+                        "length": 5,
+                        "vocabulary": 4,
+                        "difficulty": 1.5,
+                        "volume": 10,
+                        "effort": 15,
+                        "bugs": 0.0033333333333333335,
+                        "time": 0.8333333333333334
+                    },
+                    "params": 1,
+                    "line": 15,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 154.72185898874935,
+            "loc": 1,
+            "cyclomatic": 1.3333333333333333,
+            "effort": 114.47349531196694,
+            "params": 1,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/LogicalExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 7,
+                    "physical": 18
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 10,
+                        "total": 20,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "===",
+                            "[]",
+                            "- (prefix)"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 21,
+                        "total": 29,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "<anonymous>",
+                            "node",
+                            "object",
+                            "type",
+                            "\"ObjectExpression\"",
+                            "\"ArrayExpression\"",
+                            "\"FunctionExpression\"",
+                            "indexOf",
+                            1,
+                            0,
+                            "\".\"",
+                            "undefined",
+                            "\"object\"",
+                            "\"property\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 49,
+                    "vocabulary": 31,
+                    "difficulty": 6.904761904761905,
+                    "volume": 242.75561920895692,
+                    "effort": 1676.1697516808931,
+                    "bugs": 0.08091853973631898,
+                    "time": 93.12054176004962
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 28.57142857142857
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 12
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 9,
+                            "identifiers": [
+                                "<anonymous>",
+                                0,
+                                "\".\"",
+                                "undefined",
+                                "\"object\"",
+                                "\"property\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 13,
+                        "difficulty": 2.8125,
+                        "volume": 51.80615605397529,
+                        "effort": 145.70481390180552,
+                        "bugs": 0.01726871868465843,
+                        "time": 8.09471188343364
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 2,
+                        "physical": 7
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 7,
+                            "total": 9,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "===",
+                                "()",
+                                ".",
+                                "[]",
+                                "- (prefix)"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 10,
+                            "total": 12,
+                            "identifiers": [
+                                "node",
+                                "object",
+                                "type",
+                                "<anonymous>",
+                                "\"ObjectExpression\"",
+                                "\"ArrayExpression\"",
+                                "\"FunctionExpression\"",
+                                "indexOf",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 21,
+                        "vocabulary": 17,
+                        "difficulty": 4.2,
+                        "volume": 85.83671966625714,
+                        "effort": 360.51422259828,
+                        "bugs": 0.02861223988875238,
+                        "time": 20.02856792212667
+                    },
+                    "params": 1,
+                    "line": 11,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 145.41253609833987,
+            "loc": 1.5,
+            "cyclomatic": 1.5,
+            "effort": 253.10951825004275,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/MemberExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 14
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 9,
+                        "total": 16,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "===",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 24,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "<anonymous>",
+                            "node",
+                            "callee",
+                            "type",
+                            "\"FunctionExpression\"",
+                            1,
+                            0,
+                            "\"new\"",
+                            "undefined",
+                            "\"arguments\"",
+                            "\"callee\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 40,
+                    "vocabulary": 27,
+                    "difficulty": 6,
+                    "volume": 190.19550008653877,
+                    "effort": 1141.1730005192326,
+                    "bugs": 0.06339850002884626,
+                    "time": 63.39850002884626
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 8
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 9,
+                            "identifiers": [
+                                "<anonymous>",
+                                0,
+                                "\"new\"",
+                                "undefined",
+                                "\"arguments\"",
+                                "\"callee\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 13,
+                        "difficulty": 2.8125,
+                        "volume": 51.80615605397529,
+                        "effort": 145.70481390180552,
+                        "bugs": 0.01726871868465843,
+                        "time": 8.09471188343364
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "===",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 7,
+                            "identifiers": [
+                                "node",
+                                "callee",
+                                "type",
+                                "\"FunctionExpression\"",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 10,
+                        "difficulty": 2.3333333333333335,
+                        "volume": 39.863137138648355,
+                        "effort": 93.01398665684617,
+                        "bugs": 0.013287712379549451,
+                        "time": 5.167443703158121
+                    },
+                    "params": 1,
+                    "line": 11,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 154.55182726218618,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 119.35940027932585,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/NewExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 6,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 11,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "\"{}\"",
+                            "\"../safeName\"",
+                            "\"properties\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 17,
+                    "difficulty": 4.363636363636363,
+                    "volume": 106.27403387250884,
+                    "effort": 463.74123871640217,
+                    "bugs": 0.03542467795750295,
+                    "time": 25.763402150911233
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 8,
+                            "identifiers": [
+                                0,
+                                "\"{}\"",
+                                "\"../safeName\"",
+                                "require",
+                                "\"properties\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 10,
+                        "difficulty": 1.7142857142857142,
+                        "volume": 39.863137138648355,
+                        "effort": 68.33680652339717,
+                        "bugs": 0.013287712379549451,
+                        "time": 3.796489251299843
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 10,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 156.55238607408194,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 68.33680652339717,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ObjectExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 7,
+                    "physical": 15
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 16,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 25,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "safeName",
+                            "\"../safeName\"",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\":\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"key\"",
+                            "\"value\"",
+                            "node",
+                            "key",
+                            "actualise"
+                        ]
+                    },
+                    "length": 41,
+                    "vocabulary": 25,
+                    "difficulty": 4.861111111111111,
+                    "volume": 190.3981037807637,
+                    "effort": 925.5463378231568,
+                    "bugs": 0.0634660345935879,
+                    "time": 51.41924099017538
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 14.285714285714285
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 8
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "function",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 10,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\":\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"key\"",
+                                "\"value\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 15,
+                        "vocabulary": 14,
+                        "difficulty": 2.7777777777777777,
+                        "volume": 57.110323830864054,
+                        "effort": 158.6397884190668,
+                        "bugs": 0.019036774610288017,
+                        "time": 8.813321578837044
+                    },
+                    "params": 0,
+                    "line": 10,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "node",
+                                "key",
+                                "safeName"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 6,
+                        "difficulty": 2,
+                        "volume": 18.094737505048094,
+                        "effort": 36.18947501009619,
+                        "bugs": 0.006031579168349364,
+                        "time": 2.0105263894497885
+                    },
+                    "params": 1,
+                    "line": 13,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 6,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.33990063570505,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 97.4146317145815,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/Property.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 13,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"return\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"argument\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 20,
+                    "difficulty": 4.307692307692308,
+                    "volume": 112.37013046707143,
+                    "effort": 484.05594662738474,
+                    "bugs": 0.03745671015569048,
+                    "time": 26.891997034854707
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 8,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"return\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"argument\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 12,
+                        "difficulty": 2,
+                        "volume": 43.01955000865388,
+                        "effort": 86.03910001730776,
+                        "bugs": 0.014339850002884626,
+                        "time": 4.779950000961542
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.76457769251132,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 86.03910001730776,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ReturnStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 6,
+                        "total": 9,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 10,
+                        "total": 15,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "undefined",
+                            "\"expressions\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 24,
+                    "vocabulary": 16,
+                    "difficulty": 4.5,
+                    "volume": 96,
+                    "effort": 432,
+                    "bugs": 0.032,
+                    "time": 24
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 7,
+                            "identifiers": [
+                                0,
+                                "undefined",
+                                "\"expressions\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 10,
+                        "vocabulary": 8,
+                        "difficulty": 2.0999999999999996,
+                        "volume": 30,
+                        "effort": 62.999999999999986,
+                        "bugs": 0.01,
+                        "time": 3.499999999999999
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 156.83047923574097,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 62.999999999999986,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/SequenceExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 7,
+                    "physical": 18
+                },
+                "cyclomatic": 3,
+                "halstead": {
+                    "operators": {
+                        "distinct": 9,
+                        "total": 20,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "&&",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 19,
+                        "total": 30,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            "settings",
+                            1,
+                            "<anonymous>",
+                            "node",
+                            "switchcase",
+                            "test",
+                            0,
+                            "\"case\"",
+                            "\"default\"",
+                            "undefined",
+                            "\"test\"",
+                            "\"consequent\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 50,
+                    "vocabulary": 28,
+                    "difficulty": 7.105263157894737,
+                    "volume": 240.36774610288018,
+                    "effort": 1707.8760907309909,
+                    "bugs": 0.08012258203429339,
+                    "time": 94.88200504061061
+                },
+                "params": 3,
+                "line": 3,
+                "cyclomaticDensity": 42.857142857142854
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 12
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 10,
+                            "identifiers": [
+                                "settings",
+                                1,
+                                "<anonymous>",
+                                "undefined",
+                                "\"test\"",
+                                "\"consequent\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 13,
+                        "difficulty": 3.125,
+                        "volume": 59.207035490257475,
+                        "effort": 185.0219859070546,
+                        "bugs": 0.019735678496752493,
+                        "time": 10.27899921705859
+                    },
+                    "params": 1,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "&&",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 7,
+                            "identifiers": [
+                                "node",
+                                "settings",
+                                "switchcase",
+                                "test",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 10,
+                        "difficulty": 2.3333333333333335,
+                        "volume": 39.863137138648355,
+                        "effort": 93.01398665684617,
+                        "bugs": 0.013287712379549451,
+                        "time": 5.167443703158121
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "node",
+                                "test",
+                                "\"case\"",
+                                "\"default\""
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 7,
+                        "difficulty": 1.875,
+                        "volume": 22.458839376460833,
+                        "effort": 42.11032383086406,
+                        "bugs": 0.007486279792153611,
+                        "time": 2.3394624350480036
+                    },
+                    "params": 1,
+                    "line": 15,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 154.9105431427434,
+            "loc": 1,
+            "cyclomatic": 1.6666666666666667,
+            "effort": 106.71543213158827,
+            "params": 1,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/SwitchCase.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 14,
+                        "total": 17,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"switch\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"discriminant\"",
+                            "\"cases\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 27,
+                    "vocabulary": 21,
+                    "difficulty": 4.25,
+                    "volume": 118.59257041502654,
+                    "effort": 504.0184242638628,
+                    "bugs": 0.03953085680500885,
+                    "time": 28.0010235702146
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 9,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"switch\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"discriminant\"",
+                                "\"cases\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 13,
+                        "difficulty": 2,
+                        "volume": 48.105716335834195,
+                        "effort": 96.21143267166839,
+                        "bugs": 0.016035238778611398,
+                        "time": 5.345079592870466
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.3824051787387,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 96.21143267166839,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/SwitchStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 6,
+                        "total": 9,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 10,
+                        "total": 14,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "undefined",
+                            "\"this\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 23,
+                    "vocabulary": 16,
+                    "difficulty": 4.199999999999999,
+                    "volume": 92,
+                    "effort": 386.3999999999999,
+                    "bugs": 0.030666666666666665,
+                    "time": 21.46666666666666
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 6,
+                            "identifiers": [
+                                0,
+                                "undefined",
+                                "\"this\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 9,
+                        "vocabulary": 8,
+                        "difficulty": 1.7999999999999998,
+                        "volume": 27,
+                        "effort": 48.599999999999994,
+                        "bugs": 0.009,
+                        "time": 2.6999999999999997
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 157.71800752429994,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 48.599999999999994,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ThisExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 13,
+                        "total": 16,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"throw\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"argument\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 26,
+                    "vocabulary": 20,
+                    "difficulty": 4.307692307692308,
+                    "volume": 112.37013046707143,
+                    "effort": 484.05594662738474,
+                    "bugs": 0.03745671015569048,
+                    "time": 26.891997034854707
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 8,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"throw\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"argument\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 12,
+                        "vocabulary": 12,
+                        "difficulty": 2,
+                        "volume": 43.01955000865388,
+                        "effort": 86.03910001730776,
+                        "bugs": 0.014339850002884626,
+                        "time": 4.779950000961542
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.76457769251132,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 86.03910001730776,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/ThrowStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 13,
+                        "total": 17,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "undefined",
+                            "<anonymous>",
+                            "\"block\"",
+                            "\"handlers\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 27,
+                    "vocabulary": 20,
+                    "difficulty": 4.576923076923077,
+                    "volume": 116.69205856195879,
+                    "effort": 534.0905757258882,
+                    "bugs": 0.03889735285398626,
+                    "time": 29.671698651438234
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 9,
+                            "identifiers": [
+                                1,
+                                0,
+                                "undefined",
+                                "<anonymous>",
+                                "\"block\"",
+                                "\"handlers\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 12,
+                        "difficulty": 2.25,
+                        "volume": 46.604512509375034,
+                        "effort": 104.86015314609382,
+                        "bugs": 0.015534837503125011,
+                        "time": 5.825564063671879
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.08801365032298,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 104.86015314609382,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/TryStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 9,
+                        "total": 18,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "+",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 25,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "<anonymous>",
+                            "node",
+                            "operator",
+                            "\" (\"",
+                            "prefix",
+                            "\"pre\"",
+                            "\"post\"",
+                            "\"fix)\"",
+                            "undefined",
+                            "\"argument\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 43,
+                    "vocabulary": 27,
+                    "difficulty": 6.25,
+                    "volume": 204.46016259302917,
+                    "effort": 1277.8760162064323,
+                    "bugs": 0.06815338753100972,
+                    "time": 70.99311201146845
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 8,
+                            "identifiers": [
+                                0,
+                                "<anonymous>",
+                                "undefined",
+                                "\"argument\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 11,
+                        "difficulty": 3.333333333333333,
+                        "volume": 44.97261104228487,
+                        "effort": 149.90870347428287,
+                        "bugs": 0.01499087034742829,
+                        "time": 8.328261304126826
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 7,
+                            "identifiers": [
+                                "return",
+                                "+",
+                                ".",
+                                ":?"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 9,
+                            "identifiers": [
+                                "node",
+                                "operator",
+                                "\" (\"",
+                                "prefix",
+                                "\"pre\"",
+                                "\"post\"",
+                                "\"fix)\""
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 11,
+                        "difficulty": 2.5714285714285716,
+                        "volume": 55.350905898196764,
+                        "effort": 142.3309008810774,
+                        "bugs": 0.018450301966065587,
+                        "time": 7.907272271170967
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 153.86000320466215,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 146.11980217768013,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/UnaryExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 9,
+                        "total": 18,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "+",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 18,
+                        "total": 25,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "<anonymous>",
+                            "node",
+                            "operator",
+                            "\" (\"",
+                            "prefix",
+                            "\"pre\"",
+                            "\"post\"",
+                            "\"fix)\"",
+                            "undefined",
+                            "\"argument\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 43,
+                    "vocabulary": 27,
+                    "difficulty": 6.25,
+                    "volume": 204.46016259302917,
+                    "effort": 1277.8760162064323,
+                    "bugs": 0.06815338753100972,
+                    "time": 70.99311201146845
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 8,
+                            "identifiers": [
+                                0,
+                                "<anonymous>",
+                                "undefined",
+                                "\"argument\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 11,
+                        "difficulty": 3.333333333333333,
+                        "volume": 44.97261104228487,
+                        "effort": 149.90870347428287,
+                        "bugs": 0.01499087034742829,
+                        "time": 8.328261304126826
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 7,
+                            "identifiers": [
+                                "return",
+                                "+",
+                                ".",
+                                ":?"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 7,
+                            "total": 9,
+                            "identifiers": [
+                                "node",
+                                "operator",
+                                "\" (\"",
+                                "prefix",
+                                "\"pre\"",
+                                "\"post\"",
+                                "\"fix)\""
+                            ]
+                        },
+                        "length": 16,
+                        "vocabulary": 11,
+                        "difficulty": 2.5714285714285716,
+                        "volume": 55.350905898196764,
+                        "effort": 142.3309008810774,
+                        "bugs": 0.018450301966065587,
+                        "time": 7.907272271170967
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 153.86000320466215,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 146.11980217768013,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/UpdateExpression.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 13,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 13,
+                        "total": 19,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            0,
+                            "<anonymous>",
+                            "node",
+                            "kind",
+                            "undefined",
+                            "\"declarations\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 32,
+                    "vocabulary": 20,
+                    "difficulty": 5.115384615384615,
+                    "volume": 138.3016990363956,
+                    "effort": 707.4663835323313,
+                    "bugs": 0.0461005663454652,
+                    "time": 39.3036879740184
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 16.666666666666664
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 6,
+                            "total": 8,
+                            "identifiers": [
+                                0,
+                                "<anonymous>",
+                                "undefined",
+                                "\"declarations\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 11,
+                        "difficulty": 3.333333333333333,
+                        "volume": 44.97261104228487,
+                        "effort": 149.90870347428287,
+                        "bugs": 0.01499087034742829,
+                        "time": 8.328261304126826
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 2,
+                            "identifiers": [
+                                "return",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "kind"
+                            ]
+                        },
+                        "length": 5,
+                        "vocabulary": 4,
+                        "difficulty": 1.5,
+                        "volume": 10,
+                        "effort": 15,
+                        "bugs": 0.0033333333333333335,
+                        "time": 0.8333333333333334
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.91012268847996,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 82.45435173714144,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/VariableDeclaration.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 10,
+                    "physical": 22
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 10,
+                        "total": 24,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "{}",
+                            ":",
+                            "! (prefix)",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 21,
+                        "total": 32,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "safeName",
+                            "\"../safeName\"",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "<anonymous>",
+                            "identifier",
+                            "\"=\"",
+                            "filter",
+                            "node",
+                            "init",
+                            "undefined",
+                            "\"id\"",
+                            "\"init\"",
+                            "id",
+                            "actualise"
+                        ]
+                    },
+                    "length": 56,
+                    "vocabulary": 31,
+                    "difficulty": 7.619047619047619,
+                    "volume": 277.43499338166504,
+                    "effort": 2113.7904257650666,
+                    "bugs": 0.09247833112722167,
+                    "time": 117.43280143139259
+                },
+                "params": 2,
+                "line": 3,
+                "cyclomaticDensity": 10
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 3,
+                        "physical": 15
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 7,
+                            "total": 9,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "{}",
+                                ":",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 11,
+                            "total": 14,
+                            "identifiers": [
+                                1,
+                                0,
+                                "<anonymous>",
+                                "identifier",
+                                "\"=\"",
+                                "filter",
+                                "undefined",
+                                "\"id\"",
+                                "\"init\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 23,
+                        "vocabulary": 18,
+                        "difficulty": 4.454545454545454,
+                        "volume": 95.90827503317318,
+                        "effort": 427.22777060231687,
+                        "bugs": 0.03196942501105773,
+                        "time": 23.73487614457316
+                    },
+                    "params": 0,
+                    "line": 10,
+                    "cyclomaticDensity": 33.33333333333333
+                },
+                {
+                    "name": "filter",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "! (prefix)",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "node",
+                                "init"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 5,
+                        "difficulty": 2.25,
+                        "volume": 16.253496664211536,
+                        "effort": 36.57036749447595,
+                        "bugs": 0.005417832221403845,
+                        "time": 2.031687083026442
+                    },
+                    "params": 1,
+                    "line": 15,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "node",
+                                "id",
+                                "safeName"
+                            ]
+                        },
+                        "length": 7,
+                        "vocabulary": 6,
+                        "difficulty": 2,
+                        "volume": 18.094737505048094,
+                        "effort": 36.18947501009619,
+                        "bugs": 0.006031579168349364,
+                        "time": 2.0105263894497885
+                    },
+                    "params": 1,
+                    "line": 20,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 6,
+                    "path": "../safeName",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 145.22800395303037,
+            "loc": 1.6666666666666667,
+            "cyclomatic": 1,
+            "effort": 166.66253770229633,
+            "params": 0.6666666666666666,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/VariableDeclarator.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 6,
+                    "physical": 15
+                },
+                "cyclomatic": 2,
+                "halstead": {
+                    "operators": {
+                        "distinct": 8,
+                        "total": 14,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            ":?",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 16,
+                        "total": 22,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            "<anonymous>",
+                            "node",
+                            "test",
+                            0,
+                            "\"while\"",
+                            "undefined",
+                            "\"test\"",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 36,
+                    "vocabulary": 24,
+                    "difficulty": 5.5,
+                    "volume": 165.05865002596164,
+                    "effort": 907.822575142789,
+                    "bugs": 0.05501955000865388,
+                    "time": 50.43458750793272
+                },
+                "params": 1,
+                "line": 3,
+                "cyclomaticDensity": 33.33333333333333
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 9
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 5,
+                            "total": 5,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "function",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 8,
+                            "total": 9,
+                            "identifiers": [
+                                1,
+                                "<anonymous>",
+                                "\"while\"",
+                                "undefined",
+                                "\"test\"",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 13,
+                        "difficulty": 2.8125,
+                        "volume": 51.80615605397529,
+                        "effort": 145.70481390180552,
+                        "bugs": 0.01726871868465843,
+                        "time": 8.09471188343364
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "<anonymous>",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                ":?",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 4,
+                            "total": 5,
+                            "identifiers": [
+                                "node",
+                                "test",
+                                1,
+                                0
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 7,
+                        "difficulty": 1.875,
+                        "volume": 22.458839376460833,
+                        "effort": 42.11032383086406,
+                        "bugs": 0.007486279792153611,
+                        "time": 2.3394624350480036
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 200
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.3720394442222,
+            "loc": 1,
+            "cyclomatic": 1.5,
+            "effort": 93.9075688663348,
+            "params": 0.5,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/WhileStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 5,
+                    "physical": 9
+                },
+                "cyclomatic": 1,
+                "halstead": {
+                    "operators": {
+                        "distinct": 7,
+                        "total": 10,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            ".",
+                            "function",
+                            "return",
+                            "[]"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 14,
+                        "total": 17,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "traits",
+                            "\"escomplex-traits\"",
+                            "require",
+                            "exports",
+                            "get",
+                            1,
+                            0,
+                            "\"with\"",
+                            "undefined",
+                            "<anonymous>",
+                            "\"object\"",
+                            "\"body\"",
+                            "actualise"
+                        ]
+                    },
+                    "length": 27,
+                    "vocabulary": 21,
+                    "difficulty": 4.25,
+                    "volume": 118.59257041502654,
+                    "effort": 504.0184242638628,
+                    "bugs": 0.03953085680500885,
+                    "time": 28.0010235702146
+                },
+                "params": 0,
+                "line": 3,
+                "cyclomaticDensity": 20
+            },
+            "functions": [
+                {
+                    "name": "get",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 4,
+                            "total": 4,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "[]",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 9,
+                            "total": 9,
+                            "identifiers": [
+                                1,
+                                0,
+                                "\"with\"",
+                                "undefined",
+                                "<anonymous>",
+                                "\"object\"",
+                                "\"body\"",
+                                "traits",
+                                "actualise"
+                            ]
+                        },
+                        "length": 13,
+                        "vocabulary": 13,
+                        "difficulty": 2,
+                        "volume": 48.105716335834195,
+                        "effort": 96.21143267166839,
+                        "bugs": 0.016035238778611398,
+                        "time": 5.345079592870466
+                    },
+                    "params": 0,
+                    "line": 9,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 5,
+                    "path": "escomplex-traits",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 155.3824051787387,
+            "loc": 1,
+            "cyclomatic": 1,
+            "effort": 96.21143267166839,
+            "params": 0,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/WithStatement.js"
+        },
+        {
+            "aggregate": {
+                "sloc": {
+                    "logical": 38,
+                    "physical": 63
+                },
+                "cyclomatic": 6,
+                "halstead": {
+                    "operators": {
+                        "distinct": 17,
+                        "total": 76,
+                        "identifiers": [
+                            "var",
+                            "=",
+                            "()",
+                            "[]",
+                            ".",
+                            "function",
+                            "{}",
+                            "if",
+                            "===",
+                            "forin",
+                            "return",
+                            "for",
+                            "<",
+                            "+=",
+                            "&&",
+                            "!==",
+                            "+"
+                        ]
+                    },
+                    "operands": {
+                        "distinct": 40,
+                        "total": 105,
+                        "identifiers": [
+                            "\"use strict\"",
+                            "fs",
+                            "\"fs\"",
+                            "require",
+                            "loaded",
+                            false,
+                            "syntaxModules",
+                            "<anonymous>",
+                            "exports",
+                            "get",
+                            "getSyntax",
+                            "settings",
+                            "syntax",
+                            "name",
+                            "loadSyntaxModules",
+                            true,
+                            "_hasOwnProperty",
+                            "setSyntax",
+                            "fileNames",
+                            "i",
+                            "fileName",
+                            "components",
+                            "getSyntaxFileNames",
+                            0,
+                            "length",
+                            1,
+                            "\".\"",
+                            "split",
+                            "isSyntaxDefinition",
+                            "loadSyntaxModule",
+                            "__dirname",
+                            "readdirSync",
+                            "pathify",
+                            "statSync",
+                            "isFile",
+                            2,
+                            "\"index\"",
+                            "\"js\"",
+                            "directory",
+                            "\"/\""
+                        ]
+                    },
+                    "length": 181,
+                    "vocabulary": 57,
+                    "difficulty": 22.3125,
+                    "volume": 1055.7530925638184,
+                    "effort": 23556.490877830198,
+                    "bugs": 0.35191769752127283,
+                    "time": 1308.6939376572332
+                },
+                "params": 9,
+                "line": 4,
+                "cyclomaticDensity": 15.789473684210526
+            },
+            "functions": [
+                {
+                    "name": "getSyntax",
+                    "sloc": {
+                        "logical": 9,
+                        "physical": 16
+                    },
+                    "cyclomatic": 3,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 9,
+                            "total": 13,
+                            "identifiers": [
+                                "var",
+                                "=",
+                                "{}",
+                                "if",
+                                "===",
+                                "()",
+                                "forin",
+                                ".",
+                                "return"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 11,
+                            "total": 19,
+                            "identifiers": [
+                                "settings",
+                                "syntax",
+                                "<anonymous>",
+                                "name",
+                                "loaded",
+                                false,
+                                "loadSyntaxModules",
+                                true,
+                                "syntaxModules",
+                                "_hasOwnProperty",
+                                "setSyntax"
+                            ]
+                        },
+                        "length": 32,
+                        "vocabulary": 20,
+                        "difficulty": 7.7727272727272725,
+                        "volume": 138.3016990363956,
+                        "effort": 1074.9813879647113,
+                        "bugs": 0.0461005663454652,
+                        "time": 59.72118822026174
+                    },
+                    "params": 1,
+                    "line": 12,
+                    "cyclomaticDensity": 33.33333333333333
+                },
+                {
+                    "name": "loadSyntaxModules",
+                    "sloc": {
+                        "logical": 10,
+                        "physical": 14
+                    },
+                    "cyclomatic": 3,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 8,
+                            "total": 17,
+                            "identifiers": [
+                                "var",
+                                "=",
+                                "()",
+                                "for",
+                                "<",
+                                ".",
+                                "+=",
+                                "if"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 12,
+                            "total": 26,
+                            "identifiers": [
+                                "fileNames",
+                                "i",
+                                "fileName",
+                                "components",
+                                "getSyntaxFileNames",
+                                0,
+                                "length",
+                                1,
+                                "\".\"",
+                                "split",
+                                "isSyntaxDefinition",
+                                "loadSyntaxModule"
+                            ]
+                        },
+                        "length": 43,
+                        "vocabulary": 20,
+                        "difficulty": 8.666666666666666,
+                        "volume": 185.8429080801566,
+                        "effort": 1610.6385366946904,
+                        "bugs": 0.06194763602671887,
+                        "time": 89.47991870526057
+                    },
+                    "params": 0,
+                    "line": 29,
+                    "cyclomaticDensity": 30
+                },
+                {
+                    "name": "getSyntaxFileNames",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "()",
+                                "."
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 3,
+                            "identifiers": [
+                                "__dirname",
+                                "fs",
+                                "readdirSync"
+                            ]
+                        },
+                        "length": 6,
+                        "vocabulary": 6,
+                        "difficulty": 1.5,
+                        "volume": 15.509775004326936,
+                        "effort": 23.264662506490403,
+                        "bugs": 0.005169925001442312,
+                        "time": 1.292481250360578
+                    },
+                    "params": 0,
+                    "line": 44,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "isSyntaxDefinition",
+                    "sloc": {
+                        "logical": 3,
+                        "physical": 7
+                    },
+                    "cyclomatic": 2,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 7,
+                            "total": 16,
+                            "identifiers": [
+                                "if",
+                                "()",
+                                ".",
+                                "return",
+                                "&&",
+                                "===",
+                                "!=="
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 14,
+                            "total": 18,
+                            "identifiers": [
+                                "fileName",
+                                "components",
+                                "__dirname",
+                                "pathify",
+                                "fs",
+                                "statSync",
+                                "isFile",
+                                "length",
+                                2,
+                                0,
+                                "\"index\"",
+                                1,
+                                "\"js\"",
+                                false
+                            ]
+                        },
+                        "length": 34,
+                        "vocabulary": 21,
+                        "difficulty": 4.5,
+                        "volume": 149.33879237447786,
+                        "effort": 672.0245656851504,
+                        "bugs": 0.04977959745815929,
+                        "time": 37.334698093619465
+                    },
+                    "params": 2,
+                    "line": 48,
+                    "cyclomaticDensity": 66.66666666666666
+                },
+                {
+                    "name": "pathify",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 2,
+                            "total": 3,
+                            "identifiers": [
+                                "return",
+                                "+"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 3,
+                            "total": 5,
+                            "identifiers": [
+                                "directory",
+                                "fileName",
+                                "\"/\""
+                            ]
+                        },
+                        "length": 8,
+                        "vocabulary": 5,
+                        "difficulty": 1.6666666666666667,
+                        "volume": 18.575424759098897,
+                        "effort": 30.95904126516483,
+                        "bugs": 0.006191808253032966,
+                        "time": 1.7199467369536017
+                    },
+                    "params": 2,
+                    "line": 56,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "loadSyntaxModule",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 4,
+                            "identifiers": [
+                                "=",
+                                ".",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 7,
+                            "identifiers": [
+                                "name",
+                                "syntaxModules",
+                                "\".\"",
+                                "pathify",
+                                "require"
+                            ]
+                        },
+                        "length": 11,
+                        "vocabulary": 8,
+                        "difficulty": 2.0999999999999996,
+                        "volume": 33,
+                        "effort": 69.29999999999998,
+                        "bugs": 0.011,
+                        "time": 3.849999999999999
+                    },
+                    "params": 1,
+                    "line": 60,
+                    "cyclomaticDensity": 100
+                },
+                {
+                    "name": "setSyntax",
+                    "sloc": {
+                        "logical": 1,
+                        "physical": 3
+                    },
+                    "cyclomatic": 1,
+                    "halstead": {
+                        "operators": {
+                            "distinct": 3,
+                            "total": 5,
+                            "identifiers": [
+                                "=",
+                                ".",
+                                "()"
+                            ]
+                        },
+                        "operands": {
+                            "distinct": 5,
+                            "total": 9,
+                            "identifiers": [
+                                "syntax",
+                                "name",
+                                "settings",
+                                "syntaxModules",
+                                "get"
+                            ]
+                        },
+                        "length": 14,
+                        "vocabulary": 8,
+                        "difficulty": 2.7,
+                        "volume": 42,
+                        "effort": 113.4,
+                        "bugs": 0.014,
+                        "time": 6.300000000000001
+                    },
+                    "params": 3,
+                    "line": 64,
+                    "cyclomaticDensity": 100
+                }
+            ],
+            "dependencies": [
+                {
+                    "line": 6,
+                    "path": "fs",
+                    "type": "CommonJS"
+                },
+                {
+                    "line": 61,
+                    "path": "* dynamic dependency *",
+                    "type": "CommonJS"
+                }
+            ],
+            "maintainability": 128.27347132021634,
+            "loc": 3.7142857142857144,
+            "cyclomatic": 1.7142857142857142,
+            "effort": 513.509742016601,
+            "params": 1.2857142857142858,
+            "path": "/Users/ahigham/opensource/escomplex-ast-moz/src/syntax/index.js"
+        }
+    ]
+}


### PR DESCRIPTION
This changes `src/project` to use Floyd Warshall
(http://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm) for calculating
the visibility matrix, which is `O(n^3)` over the old implementation
that was `O(n^4)`

It also adds two new options, `skipCalculation` which skips over doing
the aggregation calculations and `noCoreSize` for large projects where
the `O(n^3)` is still too slow for calulcating visibility and coreSize.

Docs were also changed to reflect the processResults changes