### PR TITLE
Update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "1.13.x",
     "chai": "1.8.x",
     "escomplex-ast-moz": "0.1.x",
-    "esprima": "1.0.x"
+    "esprima": "2.6.x"
   },
   "scripts": {
     "lint": "./node_modules/jshint/bin/jshint src --config config/jshint.json",


### PR DESCRIPTION
The fossilized version of esprima used by escomplex does not appear to support
`for ... in` loops.

```
for(let key in object) {
...
}
```

All tests pass.
